### PR TITLE
Fix broken links and HTML structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,16 +4,15 @@
         <meta charset="utf-8">
         <title>Recipes YOU can try!</title>
         <link rel="stylesheet" href="style.css">
-        <h1>Odin Recipes</h1>
     </head>
     <body>
-        <!--<h1>Odin Recipes</h1>-->
+        <h1>Odin Recipes</h1>
 
         <ul class="shadow">
             <li><a class="active" href="index.html" target="_blank">Home</a> </li>
-            <li><a  href="lasagna.html" target="_blank">Lasagna</a></li>
-            <li><a  href="Beef_Sukiyaki.html" target="_blank">Beef Sukiyaki</a</li>
-            <li><a  href="Chicken_Yakitori.html" target="_blank">Chicken Yakitori</a></li>
+            <li><a  href="recipes/lasagna.html" target="_blank">Lasagna</a></li>
+            <li><a  href="recipes/Beef_Sukiyaki.html" target="_blank">Beef Sukiyaki</a></li>
+            <li><a  href="recipes/Chicken_Yakitori.html" target="_blank">Chicken Yakitori</a></li>
             <li><a  href="placeholder.html" target="_blank">Placeholder</a></li>
             <li><a  href="placeholder.html" target="_blank">Placeholder</a></li>
             <li><a  href="placeholder.html" target="_blank">Placeholder</a></li>

--- a/recipes/Beef_Sukiyaki.html
+++ b/recipes/Beef_Sukiyaki.html
@@ -7,24 +7,20 @@
     <body>
         <h1>Beef Sukiyaki</h1>
         <h2>Ingredients</h2>
-        <p>
-            <ul>
+        <ul>
                 <li>1½ cups prepared dashi stock </li>
                 <li>¾ cup soy sauce</li>
                 <li>¾ cup mirin </li>
                 <li>8 ounces shirataki noodles </li>
                 <li>1 pound beef top sirloin, thinly sliced </li>
-            </ul>  
-        </p>
+        </ul>
         <h2>Directions</h2>
-        <p2>
-            <ol>
+        <ol>
                 <li>Combine dashi, soy sauce, mirin, and sugar in a bowl and set aside.</li>
                 <li>Soak noodles in boiling water for 1 minute. Drain and rinse under cold water.</li>
                 <li>Heat 2 tablespoons canola oil; cook and stir beef in the hot oil until no longer pink, 2 to 3 minutes. Drain and set aside.</li>
                 <li>Heat 1 tablespoon canola oil in the skillet; cook and stir onion, celery, carrot, and mushrooms until softened, about 4 minutes. Stir in green onions, and dashi mixture, noodles, beef, and tofu. Bring to a simmer. Divide hot sukiyaki among four bowls and serve.</li>
-            </ol>
-        </p2>
+        </ol>
 
     </body>
 

--- a/recipes/Beef_Sukiyaki.html
+++ b/recipes/Beef_Sukiyaki.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <Title>Beef Sukiyaki</Title>
+        <title>Beef Sukiyaki</title>
     </head>
     <body>
         <h1>Beef Sukiyaki</h1>

--- a/recipes/Chicken_Yakitori.html
+++ b/recipes/Chicken_Yakitori.html
@@ -7,24 +7,20 @@
     <body>
         <h1>Chicken Yakitori</h1>
         <h2>Ingredients</h2>
-        <p>
-            <ul>
+        <ul>
                 <li>10 wooden skewers</li>
                 <li>4 skinless, boneless chicken thighs, cut into 1-inch cubes </li>
                 <li>4 scallions, sliced into 1-inch pieces </li>
                 <li>½ cup sake </li>
                 <li>½ cup soy sauce </li>
-            </ul>
-        </p>
+        </ul>
         <h2>Directions</h2>
-        <p2>
-            <ol>
+        <ol>
                 <li>Soak 10 wooden skewers in cold water for 15 minutes.</li>
                 <li>Thread chicken pieces onto the soaked skewers, alternating with scallions.</li>
                 <li>Combine sake, soy sauce, mirin, and sugar in a small saucepan and bring to a boil.</li>
                 <li>Heat a grill pan over high heat and lightly brush with vegetable oil. Add skewers and cook until chicken is no longer pink in the center, basting frequently with 1/2 of the sauce, 7 to 10 minutes per side.</li>
-            </ol>
-        </p2>
+        </ol>
     </body>
 
 </html>

--- a/recipes/Chicken_Yakitori.html
+++ b/recipes/Chicken_Yakitori.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8">
-      <Title>Chicken Yakitori</Title>
+      <title>Chicken Yakitori</title>
     </head>
     <body>
         <h1>Chicken Yakitori</h1>

--- a/recipes/lasagna.html
+++ b/recipes/lasagna.html
@@ -8,8 +8,7 @@
     <body>
         <h1>Simply Lasagna</h1>
         <h2>Ingredients</h2>
-            <p>
-                <ul>
+            <ul>
                     <li>1 pound ground beef</li>
                     <li>2 1/2 cups KRAFT shredded Low-Moisture Part-Skim Mozzeralla Chees, divided</li>
                     <li>1 (15 ounce) container POLLY-O Natural Part Skim Ricotta Cheese </li>
@@ -18,17 +17,14 @@
                     <li>1 egg, beaten </li>
                     <li>1 (24 ounce) jar spaghetti sauce </li>
                 </ul>
-            </p>
 
             <h2>Directions</h2>
-        <p2>
-            <ol>
+        <ol>
                 <li>Heat oven to 350 degrees F.</li>
                 <li>Brown meat in large skillet on medium-high heat. Meanwhile, mix 1 1/4 cups mozzarella, ricotta cheese, 1/4 cup Parmesan, parsley and egg until well blended; set aside.</li>
                 <li>Drain meat; return to skillet. Stir in spaghetti sauce. Add 1 cup water to empty sauce jar; cover with lid and shake well. Add to meat mixture; stir until well blended. </li>
                 <li>Bake 1 hour or until heated through, removing foil after 45 min. Let stand 15 min.</li>
             </ol>
-        </p2>
 
     </body>
 


### PR DESCRIPTION
## Summary
- move the page heading out of the `<head>` element
- fix navigation links to reference the `recipes` folder
- clean up recipe pages by removing invalid `<p>` and `<p2>` wrappers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68499d4b127c832a9172d338a5665ae8